### PR TITLE
Prepare for generics-sop-0.2.

### DIFF
--- a/postgresql-simple-sop.cabal
+++ b/postgresql-simple-sop.cabal
@@ -15,4 +15,4 @@ library
   ghc-options:         -Wall -fno-warn-unused-do-bind -fno-warn-orphans -fwarn-incomplete-patterns
   build-depends:       base >= 4.6 && < 5
                      , postgresql-simple
-                     , generics-sop
+                     , generics-sop >= 0.2 && < 0.3

--- a/src/Database/PostgreSQL/Simple/SOP.hs
+++ b/src/Database/PostgreSQL/Simple/SOP.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, OverloadedStrings, ScopedTypeVariables, DeriveGeneric, FlexibleInstances, ConstraintKinds, DataKinds, GADTs, TypeOperators #-}
+{-# LANGUAGE DefaultSignatures, OverloadedStrings, ScopedTypeVariables, DeriveGeneric, FlexibleInstances, ConstraintKinds, DataKinds, GADTs, TypeOperators, FlexibleContexts #-}
 
 {- |
 
@@ -41,13 +41,13 @@ import Database.PostgreSQL.Simple.ToField
 
 -- |Generic fromRow
 gfromRow
-  :: (All FromField xs, Code a ~ '[xs], SingI xs, Generic a)
+  :: (All FromField xs, Code a ~ '[xs], Generic a)
   => RowParser a
 gfromRow = to . SOP . Z <$> hsequence (hcpure fromFieldp field)
   where fromFieldp = Proxy :: Proxy FromField
 
 -- |Generic toRow
-gtoRow :: (Generic a, Code a ~ '[xs], All ToField xs, SingI xs) => a -> [Action]
+gtoRow :: (Generic a, Code a ~ '[xs], All ToField xs) => a -> [Action]
 gtoRow a =
   case from a of
     SOP (Z xs) -> hcollapse (hcliftA toFieldP (K . toField . unI) xs)


### PR DESCRIPTION
I'm about to release generics-sop-0.2 today or within the next few days, which has a few interface changes.

As part of this process, I'm looking at a number of packages that depend on generics-sop, and see how their code is impacted by the change.

In the case of `postgresql-simple-sop`, the changes are as follows:

  * The definition of `All` has changed, and it is now a type class rather than a type family. Somewhat surprisingly, this implies that you need to enable `FlexibleContexts` now.

  * The `All` constraint now implies the `SingI` constraint (which additionally has been renamed to `SListI`), so some type signatures can be simplified.